### PR TITLE
Fix missing packaging dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ai-journal-kit"
-version = "1.1.1"
+version = "1.1.2"
 description = "AI-powered journaling system with beautiful CLI for setup, customization, and updates"
 authors = [{ name = "Troy Larson", email = "troy@calvinware.com" }]
 readme = "README.md"
@@ -31,6 +31,7 @@ dependencies = [
     "platformdirs>=4.0.0",
     "pydantic>=2.0.0",
     "questionary>=2.0.0",
+    "packaging>=23.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Add `packaging>=23.0` to project dependencies in `pyproject.toml`
- Bump version from 1.1.1 to 1.1.2 for patch release

## Problem
The `packaging` module is imported in `ai_journal_kit/cli/update.py:6` but was not listed in the project dependencies. This caused a `ModuleNotFoundError` when running `uvx ai-journal-kit setup` or any other command on a fresh installation.

## Solution
Added `packaging>=23.0` to the `dependencies` array in `pyproject.toml`. This ensures the module is installed automatically when users install ai-journal-kit.

## Testing
Tested locally with:
```bash
uvx --from . ai-journal-kit --help
```
The command now runs successfully without the ModuleNotFoundError.

## Test plan
I ran it locally with:
`uvx --from /home/luka/ai-journal-kit ai-journal-kit setup` and confirmed that I didn't see the issue any more.